### PR TITLE
Added tab group name, field position and note

### DIFF
--- a/app/code/community/VinaiKopp/CategoryLink/sql/vinaikopp_categorylink_setup/install-0.1.0.php
+++ b/app/code/community/VinaiKopp/CategoryLink/sql/vinaikopp_categorylink_setup/install-0.1.0.php
@@ -6,12 +6,15 @@ $installer = Mage::getResourceModel('catalog/setup', 'catalog_setup');
 $installer->startSetup();
 
 $installer->addAttribute('catalog_category', VinaiKopp_CategoryLink_Helper_Data::ATTR_CODE_LINK, array(
-    'label' => 'Category Link URL',
-    'type' => 'varchar',
-    'input' => 'text',
+    'label'           => 'Category Link URL',
+    'type'            => 'varchar',
+    'input'           => 'text',
     'is_configurable' => 0,
-    'required' => 0,
-    'global' => Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_STORE
+    'required'        => 0,
+    'note'            => 'Must include protocol (http://, https://, ftp://, ...)',
+    'sort_order'      => 4,
+    'global'          => Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_STORE,
+    'group'           => 'General Information',
 ));
 
 $installer->endSetup();


### PR DESCRIPTION
When a category attribute is created without specifying a `group_name`, a new tab ("General") appears in the category pane. This might be confusing for some merchants, hence the fix - including a position value that places the new URL field near the original URL key field plus a (hopefully) useful comment.
